### PR TITLE
fixed rho computation

### DIFF
--- a/src/LM_alg.jl
+++ b/src/LM_alg.jl
@@ -131,13 +131,17 @@ function LM(
     end
 
     # define model and update ρ
-    mk(d) = φ(d) + ψ(d)
+    mk(d) = begin
+      jprod_residual!(nls, xk, d, JdFk)
+      JdFk .+= Fk
+      return dot(JdFk, JdFk) / 2 + ψ(d)
+    end
 
     # take first proximal gradient step s1 and see if current xk is nearly stationary
     subsolver_options.ν = 1 / νInv
     ∇fk .*= -subsolver_options.ν  # reuse gradient storage
     prox!(s, ψ, ∇fk, subsolver_options.ν)
-    ξ1 = fk + hk - mk(s) + max(1, abs(fk + hk)) * 10 * eps()  # TODO: isn't mk(s) returned by subsolver?
+    ξ1 = fk + hk - (φ(s) + ψ(s)) + max(1, abs(fk + hk)) * 10 * eps()  # TODO: isn't mk(s) returned by subsolver?
     ξ1 > 0 || error("LM: first prox-gradient step should produce a decrease but ξ1 = $(ξ1)")
 
     if sqrt(ξ1) < ϵ
@@ -161,15 +165,16 @@ function LM(
     fkn = dot(Fkn, Fkn) / 2
     hkn = h(xkn)
     hkn == -Inf && error("nonsmooth term is not proper")
-
-    ξ = fk + hk - mk(s) + max(1, abs(fk + hk)) * 10 * eps()  # TODO: isn't mk(s) returned by subsolver?
+    mks = mk(s)
+    Δm = fk + hk - mks + max(1, abs(hk)) * 10 * eps()
+    ξ = Δm - σk * dot(s, s)/2  # TODO: isn't mk(s) returned by subsolver?
 
     if (ξ ≤ 0 || isnan(ξ))
       error("LM: failed to compute a step: ξ = $ξ")
     end
 
     Δobj = fk + hk - (fkn + hkn) + max(1, abs(fk + hk)) * 10 * eps()
-    ρk = Δobj / (ξ + σk * dot(s, s) / 2)
+    ρk = Δobj / Δm
 
     σ_stat = (η2 ≤ ρk < Inf) ? "↘" : (ρk < η1 ? "↗" : "=")
 

--- a/src/LM_alg.jl
+++ b/src/LM_alg.jl
@@ -131,12 +131,7 @@ function LM(
     end
 
     # define model and update ρ
-    mk(d) = begin
-      jprod_residual!(nls, xk, d, JdFk)
-      JdFk .+= Fk
-      # JdFk = Jk * d + Fk
-      return dot(JdFk, JdFk) / 2 + σk * dot(d, d) / 2 + ψ(d)
-    end
+    mk(d) = φ(d) + ψ(d)
 
     # take first proximal gradient step s1 and see if current xk is nearly stationary
     subsolver_options.ν = 1 / νInv
@@ -174,7 +169,7 @@ function LM(
     end
 
     Δobj = fk + hk - (fkn + hkn) + max(1, abs(fk + hk)) * 10 * eps()
-    ρk = Δobj / ξ
+    ρk = Δobj / (ξ + σk * dot(s, s) / 2)
 
     σ_stat = (η2 ≤ ρk < Inf) ? "↘" : (ρk < η1 ? "↗" : "=")
 

--- a/src/R2_alg.jl
+++ b/src/R2_alg.jl
@@ -156,7 +156,7 @@ function R2(
     hkn == -Inf && error("nonsmooth term is not proper")
 
     Δobj = (fk + hk) - (fkn + hkn) + max(1, abs(fk + hk)) * 10 * eps()
-    ρk = Δobj / (hk - mks +  max(1, abs(hk)) * 10 * eps())
+    ρk = Δobj / Δm
 
     σ_stat = (η2 ≤ ρk < Inf) ? "↘" : (ρk < η1 ? "↗" : "=")
 

--- a/src/R2_alg.jl
+++ b/src/R2_alg.jl
@@ -144,7 +144,7 @@ function R2(
     ξ = Δm - σk * dot(s, s) / 2
     ξ > 0 || error("R2: prox-gradient step should produce a decrease but ξ = $(ξ)")
 
-    if sqrt(ξ) < ϵ
+    if sqrt(ξ) * σk < ϵ
       optimal = true
       verbose == 0 || @info "R2: terminating with ξ = $ξ"
       continue

--- a/src/R2_alg.jl
+++ b/src/R2_alg.jl
@@ -109,7 +109,6 @@ function R2(
   s = zero(xk)
   ψ = shifted(h, xk)
 
-  k = 0
   Fobj_hist = zeros(maxIter)
   Hobj_hist = zeros(maxIter)
   Complex_hist = zeros(Int, maxIter)
@@ -136,12 +135,12 @@ function R2(
 
     # define model
     φk(d) = dot(∇fk, d)
-    mk(d) = φk(d) + σk * dot(d, d) / 2 + ψ(d)
+    mk(d) = φk(d) + ψ(d)
 
     prox!(s, ψ, mν∇fk, ν)
     Complex_hist[k] += 1
     mks = mk(s)
-    ξ = hk - mks + max(1, abs(hk)) * 10 * eps()
+    ξ = hk - mks - σk * dot(s, s) / 2 + max(1, abs(hk)) * 10 * eps()
     ξ > 0 || error("R2: prox-gradient step should produce a decrease but ξ = $(ξ)")
 
     if sqrt(ξ) < ϵ
@@ -156,7 +155,7 @@ function R2(
     hkn == -Inf && error("nonsmooth term is not proper")
 
     Δobj = (fk + hk) - (fkn + hkn) + max(1, abs(fk + hk)) * 10 * eps()
-    ρk = Δobj / ξ
+    ρk = Δobj / (hk - mks +  max(1, abs(hk)) * 10 * eps())
 
     σ_stat = (η2 ≤ ρk < Inf) ? "↘" : (ρk < η1 ? "↗" : "=")
 

--- a/src/R2_alg.jl
+++ b/src/R2_alg.jl
@@ -140,7 +140,8 @@ function R2(
     prox!(s, ψ, mν∇fk, ν)
     Complex_hist[k] += 1
     mks = mk(s)
-    ξ = hk - mks - σk * dot(s, s) / 2 + max(1, abs(hk)) * 10 * eps()
+    Δm = hk - mks + max(1, abs(hk)) * 10 * eps()
+    ξ = Δm - σk * dot(s, s) / 2
     ξ > 0 || error("R2: prox-gradient step should produce a decrease but ξ = $(ξ)")
 
     if sqrt(ξ) < ϵ

--- a/src/R2_alg.jl
+++ b/src/R2_alg.jl
@@ -144,7 +144,7 @@ function R2(
     ξ = Δm - σk * dot(s, s) / 2
     ξ > 0 || error("R2: prox-gradient step should produce a decrease but ξ = $(ξ)")
 
-    if sqrt(ξ) * σk < ϵ
+    if sqrt(ξ) < ϵ
       optimal = true
       verbose == 0 || @info "R2: terminating with ξ = $ξ"
       continue


### PR DESCRIPTION
Redefined model in LM to have \varphi + \psi, changed rho computation in its denominator to exclude $\sigma_k/2 \|s\|^2$