### PR TITLE
added counter for 'gradient' nls evals, added test to compare length …

### DIFF
--- a/src/LMTR_alg.jl
+++ b/src/LMTR_alg.jl
@@ -93,6 +93,7 @@ function LMTR(
   Fobj_hist = zeros(maxIter)
   Hobj_hist = zeros(maxIter)
   Complex_hist = zeros(Int, maxIter)
+  Grad_hist = zeros(Int, maxIter)
   if verbose > 0
     #! format: off
     @info @sprintf "%6s %8s %8s %8s %7s %7s %8s %7s %7s %7s %7s %1s" "outer" "inner" "f(x)" "h(x)" "√ξ1" "√ξ" "ρ" "Δ" "‖x‖" "‖s‖" "1/ν" "TR"
@@ -123,6 +124,7 @@ function LMTR(
     elapsed_time = time() - start_time
     Fobj_hist[k] = fk
     Hobj_hist[k] = hk
+    Grad_hist[k] = nls.counters.neval_jprod_residual
 
     # model for first prox-gradient iteration
     φ1(d) = begin
@@ -261,5 +263,6 @@ function LMTR(
   set_solver_specific!(stats, :Hhist, Hobj_hist[1:k])
   set_solver_specific!(stats, :NonSmooth, h)
   set_solver_specific!(stats, :SubsolverCounter, Complex_hist[1:k])
+  set_solver_specific!(stats, :NLSGradHist, Grad_hist[1:k])
   return stats
 end

--- a/src/LMTR_alg.jl
+++ b/src/LMTR_alg.jl
@@ -168,7 +168,7 @@ function LMTR(
       continue
     end
 
-    subsolver_options.ϵa = k == 1 ? 1.0e-5 : max(ϵ, min(1.0e-1, ξ1 / 10))
+    subsolver_options.ϵa = k == 1 ? 1.0e0 : max(ϵ, min(1.0e0, ξ1/2))
     set_radius!(ψ, min(β * χ(s), Δk))
     s, iter, _ = with_logger(subsolver_logger) do
       subsolver(φ, ∇φ!, ψ, subsolver_options, s)

--- a/src/LMTR_alg.jl
+++ b/src/LMTR_alg.jl
@@ -94,6 +94,8 @@ function LMTR(
   Hobj_hist = zeros(maxIter)
   Complex_hist = zeros(Int, maxIter)
   Grad_hist = zeros(Int, maxIter)
+  Resid_hist = zeros(Int, maxIter)
+
   if verbose > 0
     #! format: off
     @info @sprintf "%6s %8s %8s %8s %7s %7s %8s %7s %7s %7s %7s %1s" "outer" "inner" "f(x)" "h(x)" "√ξ1" "√ξ" "ρ" "Δ" "‖x‖" "‖s‖" "1/ν" "TR"
@@ -124,7 +126,8 @@ function LMTR(
     elapsed_time = time() - start_time
     Fobj_hist[k] = fk
     Hobj_hist[k] = hk
-    Grad_hist[k] = nls.counters.neval_jprod_residual
+    Grad_hist[k] = nls.counters.neval_jtprod_residual + nls.counters.neval_jprod_residual
+    Resid_hist[k] = nls.counters.neval_residual
 
     # model for first prox-gradient iteration
     φ1(d) = begin
@@ -264,5 +267,6 @@ function LMTR(
   set_solver_specific!(stats, :NonSmooth, h)
   set_solver_specific!(stats, :SubsolverCounter, Complex_hist[1:k])
   set_solver_specific!(stats, :NLSGradHist, Grad_hist[1:k])
+  set_solver_specific!(stats, :ResidHist, Resid_hist[1:k])
   return stats
 end

--- a/src/LM_alg.jl
+++ b/src/LM_alg.jl
@@ -91,6 +91,7 @@ function LM(
   Fobj_hist = zeros(maxIter)
   Hobj_hist = zeros(maxIter)
   Complex_hist = zeros(Int, maxIter)
+  Grad_hist = zeros(Int, maxIter)
   if verbose > 0
     #! format: off
     @info @sprintf "%6s %8s %8s %8s %7s %7s %8s %7s %7s %7s %7s %1s" "outer" "inner" "f(x)" "h(x)" "√ξ1" "√ξ" "ρ" "σ" "‖x‖" "‖s‖" "‖Jₖ‖²" "reg"
@@ -119,6 +120,7 @@ function LM(
     elapsed_time = time() - start_time
     Fobj_hist[k] = fk
     Hobj_hist[k] = hk
+    Grad_hist[k] = nls.counters.neval_jprod_residual
 
     # model for first prox-gradient iteration
     φ1(d) = begin
@@ -260,5 +262,6 @@ function LM(
   set_solver_specific!(stats, :Hhist, Hobj_hist[1:k])
   set_solver_specific!(stats, :NonSmooth, h)
   set_solver_specific!(stats, :SubsolverCounter, Complex_hist[1:k])
+  set_solver_specific!(stats, :NLSGradHist, Grad_hist[1:k])
   return stats
 end

--- a/src/LM_alg.jl
+++ b/src/LM_alg.jl
@@ -170,7 +170,7 @@ function LM(
       continue
     end
 
-    subsolver_options.ϵa = k == 1 ? 1.0e-1 : max(ϵ, min(1.0e-2, ξ1 / 10))
+    subsolver_options.ϵa = k == 1 ? 1.0e0 : max(ϵ, min(1.0e0, ξ1/2))
     @debug "setting inner stopping tolerance to" subsolver_options.optTol
     s, iter, _ = with_logger(subsolver_logger) do
       subsolver(φ, ∇φ!, ψ, subsolver_options, s)

--- a/src/LM_alg.jl
+++ b/src/LM_alg.jl
@@ -92,6 +92,8 @@ function LM(
   Hobj_hist = zeros(maxIter)
   Complex_hist = zeros(Int, maxIter)
   Grad_hist = zeros(Int, maxIter)
+  Resid_hist = zeros(Int, maxIter)
+
   if verbose > 0
     #! format: off
     @info @sprintf "%6s %8s %8s %8s %7s %7s %8s %7s %7s %7s %7s %1s" "outer" "inner" "f(x)" "h(x)" "√ξ1" "√ξ" "ρ" "σ" "‖x‖" "‖s‖" "‖Jₖ‖²" "reg"
@@ -120,7 +122,8 @@ function LM(
     elapsed_time = time() - start_time
     Fobj_hist[k] = fk
     Hobj_hist[k] = hk
-    Grad_hist[k] = nls.counters.neval_jprod_residual
+    Grad_hist[k] = nls.counters.neval_jtprod_residual + nls.counters.neval_jprod_residual
+    Resid_hist[k] = nls.counters.neval_residual
 
     # model for first prox-gradient iteration
     φ1(d) = begin
@@ -263,5 +266,6 @@ function LM(
   set_solver_specific!(stats, :NonSmooth, h)
   set_solver_specific!(stats, :SubsolverCounter, Complex_hist[1:k])
   set_solver_specific!(stats, :NLSGradHist, Grad_hist[1:k])
+  set_solver_specific!(stats, :ResidHist, Resid_hist[1:k])
   return stats
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -81,6 +81,8 @@ for (h, h_name) ∈ ((NormL0(λ), "l0"), (NormL1(λ), "l1"), (IndBallL0(10 * com
       @test typeof(out.dual_feas) == eltype(out.solution)
       @test length(out.solver_specific[:Fhist]) == length(out.solver_specific[:Hhist])
       @test length(out.solver_specific[:Fhist]) == length(out.solver_specific[:SubsolverCounter])
+      @test length(out.solver_specific[:Fhist]) == length(out.solver_specific[:NLSGradHist])
+      @test out.solver_specific[:NLSGradHist][end] == bpdn_nls.counters.neval_jprod_residual
       @test obj(bpdn_nls, out.solution) == out.solver_specific[:Fhist][end]
       @test h(out.solution) == out.solver_specific[:Hhist][end]
       @test out.status == :first_order
@@ -104,6 +106,8 @@ for (h, h_name) ∈ ((NormL1(λ), "l1"),)
     @test length(LMTR_out.solver_specific[:Fhist]) == length(LMTR_out.solver_specific[:Hhist])
     @test length(LMTR_out.solver_specific[:Fhist]) ==
           length(LMTR_out.solver_specific[:SubsolverCounter])
+    @test length(LMTR_out.solver_specific[:Fhist]) == length(LMTR_out.solver_specific[:NLSGradHist])
+    @test LMTR_out.solver_specific[:NLSGradHist][end] == bpdn_nls.counters.neval_jprod_residual
     @test obj(bpdn_nls, LMTR_out.solution) == LMTR_out.solver_specific[:Fhist][end]
     @test h(LMTR_out.solution) == LMTR_out.solver_specific[:Hhist][end]
     @test LMTR_out.status == :first_order


### PR DESCRIPTION
…and final 'count'
I added a variable to the output struct that stores jtprod_residual counts at that particular iterate. The tests compare it's length and makes sure the final count is the same as the one in the nls.counter.neval_jtprod_residual. 