### PR TITLE
Change random seed bpdn-cstr after problem update

### DIFF
--- a/benchmarks/tables/bpdn-constr-table.jl
+++ b/benchmarks/tables/bpdn-constr-table.jl
@@ -1,7 +1,7 @@
 include("regulopt-tables.jl")
 
 # model
-Random.seed!(1234)
+Random.seed!(12)
 compound = 1
 model, nls_model, sol = bpdn_model(compound, bounds = true)
 

--- a/examples/demo-bpdn-constr.jl
+++ b/examples/demo-bpdn-constr.jl
@@ -6,7 +6,7 @@ using Printf
 
 include("plot-utils-bpdn.jl")
 
-Random.seed!(1234)
+Random.seed!(12)
 
 function demo_solver(f, nls, sol, h, χ, suffix = "l0-linf")
   options = ROSolverOptions(


### PR DESCRIPTION
Following https://github.com/JuliaSmoothOptimizers/RegularizedProblems.jl/pull/40 , I changed the random seed so that the nonzero elements are more "separated" so that we can see the 10 components.