### PR TITLE
Add NLSModel to NNMF ouput arguments

### DIFF
--- a/benchmarks/tables/nnmf-table.jl
+++ b/benchmarks/tables/nnmf-table.jl
@@ -2,7 +2,7 @@ include("regulopt-tables.jl")
 
 Random.seed!(1234)
 m, n, k = 100, 50, 5
-model, A, selected = nnmf_model(m, n, k)
+model, nls_model, A, selected = nnmf_model(m, n, k)
 f = LSR1Model(model)
 λ = 1.0e-1 # norm(grad(model, rand(model.meta.nvar)), Inf) / 100
 h = NormL0(λ)

--- a/examples/demo-nnmf-constr.jl
+++ b/examples/demo-nnmf-constr.jl
@@ -50,7 +50,7 @@ end
 
 function demo_nnmf()
   m, n, k = 100, 50, 5
-  model, A, selected = nnmf_model(m, n, k)
+  model, nls_model, A, selected = nnmf_model(m, n, k)
   f = LSR1Model(model)
   λ = norm(grad(model, rand(model.meta.nvar)), Inf) / 200
   demo_solver(f, NormL0(λ), NormLinf(1.0), selected, A, m, n, k, "l0-linf")


### PR DESCRIPTION
This should fix the issues with the nnmf demo since https://github.com/JuliaSmoothOptimizers/RegularizedProblems.jl/pull/42 added the NLS model to the outputs.