### PR TITLE
Resolve R2 Allocation test

### DIFF
--- a/src/R2_alg.jl
+++ b/src/R2_alg.jl
@@ -132,7 +132,7 @@ For advanced usage, first define a solver "R2Solver" to preallocate the memory u
     solver = R2Solver(reg_nlp)
     solve!(solver, reg_nlp)
 
-    stats = GenericExecutionStats(reg_nlp.model)
+    stats = GenericExecutionStats(reg_nlp)
     solver = R2Solver(reg_nlp)
     solve!(solver, reg_nlp, stats)
 
@@ -292,7 +292,7 @@ function R2(reg_nlp::AbstractRegularizedNLPModel; kwargs...)
   kwargs_dict = Dict(kwargs...)
   max_iter = pop!(kwargs_dict, :max_iter, 10000)
   solver = R2Solver(reg_nlp, max_iter = max_iter)
-  stats = GenericExecutionStats(reg_nlp.model)
+  stats = GenericExecutionStats(reg_nlp.model) # TODO: change this to `stats = GenericExecutionStats(reg_nlp)` when FHist etc. is ruled out.
   cb = pop!(
     kwargs_dict,
     :callback,

--- a/src/R2_alg.jl
+++ b/src/R2_alg.jl
@@ -132,7 +132,7 @@ For advanced usage, first define a solver "R2Solver" to preallocate the memory u
     solver = R2Solver(reg_nlp)
     solve!(solver, reg_nlp)
 
-    stats = GenericExecutionStats(reg_nlp)
+    stats = RegularizedExecutionStats(reg_nlp)
     solver = R2Solver(reg_nlp)
     solve!(solver, reg_nlp, stats)
 
@@ -292,7 +292,7 @@ function R2(reg_nlp::AbstractRegularizedNLPModel; kwargs...)
   kwargs_dict = Dict(kwargs...)
   max_iter = pop!(kwargs_dict, :max_iter, 10000)
   solver = R2Solver(reg_nlp, max_iter = max_iter)
-  stats = GenericExecutionStats(reg_nlp.model) # TODO: change this to `stats = GenericExecutionStats(reg_nlp)` when FHist etc. is ruled out.
+  stats = GenericExecutionStats(reg_nlp.model) # TODO: change this to `stats = RegularizedExecutionStats(reg_nlp)` when FHist etc. is ruled out.
   cb = pop!(
     kwargs_dict,
     :callback,

--- a/src/R2_alg.jl
+++ b/src/R2_alg.jl
@@ -239,7 +239,7 @@ function R2(
     :status => stats.status,
     :fk => stats.solver_specific[:smooth_obj],
     :hk => stats.solver_specific[:nonsmooth_obj],
-    :ξ => stats.solver_specific[:xi],
+    :ξ => stats.dual_feas,
     :elapsed_time => stats.elapsed_time,
   )
   return stats.solution, stats.iter, outdict
@@ -416,7 +416,6 @@ function SolverCore.solve!(
   (ξ < 0 && sqrt_ξ_νInv > neg_tol) &&
     error("R2: prox-gradient step should produce a decrease but ξ = $(ξ)")
 
-  set_solver_specific!(stats, :xi, sqrt_ξ_νInv)
   set_status!(
     stats,
     get_status(
@@ -501,7 +500,6 @@ function SolverCore.solve!(
     (ξ < 0 && sqrt_ξ_νInv > neg_tol) &&
       error("R2: prox-gradient step should produce a decrease but ξ = $(ξ)")
 
-    set_solver_specific!(stats, :xi, sqrt_ξ_νInv)
     set_status!(
       stats,
       get_status(
@@ -540,6 +538,7 @@ function SolverCore.solve!(
   end
 
   set_solution!(stats, xk)
+  set_residuals!(stats, zero(eltype(xk)), sqrt_ξ_νInv)
   return stats
 end
 

--- a/src/TRDH_alg.jl
+++ b/src/TRDH_alg.jl
@@ -67,12 +67,12 @@ function TRDH(
     u_bound = nlp.meta.uvar,
     kwargs...,
   )
-  ξ = outdict[:ξ]
+  sqrt_ξ_νInv = outdict[:sqrt_ξ_νInv]
   stats = GenericExecutionStats(nlp)
   set_status!(stats, outdict[:status])
   set_solution!(stats, xk)
   set_objective!(stats, outdict[:fk] + outdict[:hk])
-  set_residuals!(stats, zero(eltype(xk)), ξ)
+  set_residuals!(stats, zero(eltype(xk)), sqrt_ξ_νInv)
   set_iter!(stats, k)
   set_time!(stats, outdict[:elapsed_time])
   set_solver_specific!(stats, :Fhist, outdict[:Fhist])
@@ -362,7 +362,7 @@ function TRDH(
     :status => status,
     :fk => fk,
     :hk => hk,
-    :ξ => sqrt_ξ_νInv,
+    :sqrt_ξ_νInv => sqrt_ξ_νInv,
     :elapsed_time => elapsed_time,
   )
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,3 +1,7 @@
+export GenericExecutionStats
+
+import SolverCore.GenericExecutionStats
+
 # use Arpack to obtain largest eigenvalue in magnitude with a minimum of robustness
 function LinearAlgebra.opnorm(B; kwargs...)
   _, s, _ = tsvd(B)
@@ -20,3 +24,20 @@ ShiftedProximalOperators.iprox!(
 
 LinearAlgebra.diag(op::AbstractDiagonalQuasiNewtonOperator) = copy(op.d)
 LinearAlgebra.diag(op::SpectralGradient{T}) where {T} = zeros(T, op.nrow) .* op.d[1]
+
+"""
+    GenericExecutionStats(reg_nlp :: AbstractRegularizedNLPModel{T, V})
+
+Construct a GenericExecutionStats object from an AbstractRegularizedNLPModel. 
+More specifically, construct a GenericExecutionStats on the NLPModel of reg_nlp and add three solver_specific entries namely :smooth_obj, :nonsmooth_obj and :xi.
+This is useful for reducing the number of allocations when calling solve!(..., reg_nlp, stats) and should be used by default.
+Warning: This should *not* be used when adding other solver_specific entries that do not have the current scalar type. 
+For instance, when one adds the history of the objective value as a solver_specific entry (which has Vector{T} type), this will cause an error and `GenericExecutionStats(reg_nlp.model)` should be used instead.
+"""
+function GenericExecutionStats(reg_nlp :: AbstractRegularizedNLPModel{T, V}) where{T, V}
+  stats = GenericExecutionStats(reg_nlp.model, solver_specific = Dict{Symbol, T}())
+  set_solver_specific!(stats, :smooth_obj, T(Inf))
+  set_solver_specific!(stats, :nonsmooth_obj, T(Inf))
+  set_solver_specific!(stats, :xi, T(Inf))
+  return stats
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,4 +1,4 @@
-export GenericExecutionStats
+export RegularizedExecutionStats
 
 import SolverCore.GenericExecutionStats
 
@@ -32,9 +32,8 @@ Construct a GenericExecutionStats object from an AbstractRegularizedNLPModel.
 More specifically, construct a GenericExecutionStats on the NLPModel of reg_nlp and add three solver_specific entries namely :smooth_obj, :nonsmooth_obj and :xi.
 This is useful for reducing the number of allocations when calling solve!(..., reg_nlp, stats) and should be used by default.
 Warning: This should *not* be used when adding other solver_specific entries that do not have the current scalar type. 
-For instance, when one adds the history of the objective value as a solver_specific entry (which has Vector{T} type), this will cause an error and `GenericExecutionStats(reg_nlp.model)` should be used instead.
 """
-function GenericExecutionStats(reg_nlp :: AbstractRegularizedNLPModel{T, V}) where{T, V}
+function RegularizedExecutionStats(reg_nlp :: AbstractRegularizedNLPModel{T, V}) where{T, V}
   stats = GenericExecutionStats(reg_nlp.model, solver_specific = Dict{Symbol, T}())
   set_solver_specific!(stats, :smooth_obj, T(Inf))
   set_solver_specific!(stats, :nonsmooth_obj, T(Inf))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -37,6 +37,5 @@ function RegularizedExecutionStats(reg_nlp :: AbstractRegularizedNLPModel{T, V})
   stats = GenericExecutionStats(reg_nlp.model, solver_specific = Dict{Symbol, T}())
   set_solver_specific!(stats, :smooth_obj, T(Inf))
   set_solver_specific!(stats, :nonsmooth_obj, T(Inf))
-  set_solver_specific!(stats, :xi, T(Inf))
   return stats
 end

--- a/test/test_allocs.jl
+++ b/test/test_allocs.jl
@@ -41,7 +41,7 @@ end
     for solver ∈ (:R2Solver,)
       reg_nlp = RegularizedNLPModel(bpdn, h)
       solver = eval(solver)(reg_nlp)
-      stats = GenericExecutionStats(reg_nlp)
+      stats = RegularizedExecutionStats(reg_nlp)
       @test @wrappedallocs(solve!(solver, reg_nlp, stats)) == 0
     end
   end

--- a/test/test_allocs.jl
+++ b/test/test_allocs.jl
@@ -41,7 +41,7 @@ end
     for solver ∈ (:R2Solver,)
       reg_nlp = RegularizedNLPModel(bpdn, h)
       solver = eval(solver)(reg_nlp)
-      stats = GenericExecutionStats(bpdn, solver_specific = Dict{Symbol, Float64}())
+      stats = GenericExecutionStats(reg_nlp)
       @test @wrappedallocs(solve!(solver, reg_nlp, stats)) == 0
     end
   end


### PR DESCRIPTION
@dpo @MohamedLaghdafHABIBOULLAH 
I think this solves #161.
I added a function that constructs a `GenericExecutionStats` on a `RegularizedNLPModel`.
solver_specific entries are added during the construction, this removes the allocation in `solve!` caused by adding an uninitialized solver_specific entry in stats. 

Also, for type stability, I had to specify that solver_specific entries are the same type as the one added in this new constructor, else there are allocations as well. This might cause issues if used without care.