### PR TITLE
Bump LinearOperators.jl compat to 2.10

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ SolverCore = "ff4d7338-4cf1-434d-91df-b86cb86fb843"
 Arpack = "7d9fca2a-8960-54d3-9f78-7d1dccf2cb97"
 
 [compat]
-LinearOperators = "2.9.1"
+LinearOperators = "2.10.0"
 NLPModels = "0.19, 0.20"
 NLPModelsModifiers = "0.7"
 Percival = "0.7.2"

--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ SolverCore = "ff4d7338-4cf1-434d-91df-b86cb86fb843"
 Arpack = "7d9fca2a-8960-54d3-9f78-7d1dccf2cb97"
 
 [compat]
-LinearOperators = "2.9"
+LinearOperators = "2.9.1"
 NLPModels = "0.19, 0.20"
 NLPModelsModifiers = "0.7"
 Percival = "0.7.2"


### PR DESCRIPTION
Should solve allocation issues in the newer version of `R2DH.jl`, see #172.