### PR TITLE
R2N & R2DH : add sigma and sigma_cauchy entry to stats

### DIFF
--- a/src/R2DH.jl
+++ b/src/R2DH.jl
@@ -326,6 +326,8 @@ function SolverCore.solve!(
   set_objective!(stats, fk + hk)
   set_solver_specific!(stats, :smooth_obj, fk)
   set_solver_specific!(stats, :nonsmooth_obj, hk)
+  set_solver_specific!(stats, :sigma, σk)
+  set_solver_specific!(stats, :sigma_cauchy, 1/ν₁)
   m_monotone > 1 && (m_fh_hist[(stats.iter) % (m_monotone - 1) + 1] = fk + hk)
 
   φ(d) = begin
@@ -424,6 +426,8 @@ function SolverCore.solve!(
     set_objective!(stats, fk + hk)
     set_solver_specific!(stats, :smooth_obj, fk)
     set_solver_specific!(stats, :nonsmooth_obj, hk)
+    set_solver_specific!(stats, :sigma, σk)
+    set_solver_specific!(stats, :sigma_cauchy, 1/ν₁)
     set_iter!(stats, stats.iter + 1)
     set_time!(stats, time() - start_time)
 

--- a/src/R2N.jl
+++ b/src/R2N.jl
@@ -304,6 +304,8 @@ function SolverCore.solve!(
   set_objective!(stats, fk + hk)
   set_solver_specific!(stats, :smooth_obj, fk)
   set_solver_specific!(stats, :nonsmooth_obj, hk)
+  set_solver_specific!(stats, :sigma, σk)
+  set_solver_specific!(stats, :sigma_cauchy, 1/ν₁)
   m_monotone > 1 && (m_fh_hist[stats.iter % (m_monotone - 1) + 1] = fk + hk)
 
   φ1 = let ∇fk = ∇fk
@@ -439,6 +441,8 @@ function SolverCore.solve!(
     set_objective!(stats, fk + hk)
     set_solver_specific!(stats, :smooth_obj, fk)
     set_solver_specific!(stats, :nonsmooth_obj, hk)
+    set_solver_specific!(stats, :sigma, σk)
+    set_solver_specific!(stats, :sigma_cauchy, 1/ν₁)
     set_iter!(stats, stats.iter + 1)
     set_time!(stats, time() - start_time)
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -112,6 +112,7 @@ function RegularizedExecutionStats(reg_nlp::AbstractRegularizedNLPModel{T, V}) w
   set_solver_specific!(stats, :smooth_obj, T(Inf))
   set_solver_specific!(stats, :nonsmooth_obj, T(Inf))
   set_solver_specific!(stats, :sigma, T(Inf))
+  set_solver_specific!(stats, :sigma_cauchy, T(Inf))
   set_solver_specific!(stats, :radius, T(Inf))
   return stats
 end


### PR DESCRIPTION
I added more information in the R2N so that the user can read more things from the execution of R2N.

I added the sigma entry as for R2.
I added the sigma_cauchy entry that is the regularization parameter used for computing the Cauchy step (which actually the regularization parameter i am interested in when I use R2N as a subsolver)

Can you please review when you have some time available @dpo ? 
Thank you !