### PR TITLE
Add v0.21 to NLPModels compatibility

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,7 @@ Arpack = "7d9fca2a-8960-54d3-9f78-7d1dccf2cb97"
 
 [compat]
 LinearOperators = "2.10.0"
-NLPModels = "0.19, 0.20"
+NLPModels = "0.19, 0.20, 0.21"
 NLPModelsModifiers = "0.7"
 Percival = "0.7.2"
 ProximalOperators = "0.15"


### PR DESCRIPTION
I often need it when I want to use CUTEst with versions later than 1.0 (which I need for using it on Windows).
I see no reason for not having it.