### PR TITLE
JSO Compliance: TR & TRDH

### DIFF
--- a/src/TRDH_alg.jl
+++ b/src/TRDH_alg.jl
@@ -90,13 +90,135 @@ function TRDHSolver(
   )
 end
 
+"""
+    TRDH(reg_nlp; kwargs…)
+    TRDH(nlp, h, χ, options; kwargs...)
+    TRDH(f, ∇f!, h, options, x0)
+
+A trust-region method with diagonal Hessian approximation for the problem
+
+    min f(x) + h(x)
+
+where f: ℝⁿ → ℝ has a Lipschitz-continuous Jacobian, and h: ℝⁿ → ℝ is
+lower semi-continuous and proper.
+
+About each iterate xₖ, a step sₖ is computed as an approximate solution of
+
+    min  φ(s; xₖ) + ψ(s; xₖ)  subject to  ‖s‖ ≤ Δₖ
+
+where φ(s ; xₖ) = f(xₖ) + ∇f(xₖ)ᵀs + ½ sᵀ Dₖ s  is a quadratic approximation of f about xₖ,
+ψ(s; xₖ) = h(xₖ + s), ‖⋅‖ is a user-defined norm, Dₖ is a diagonal Hessian approximation
+and Δₖ > 0 is the trust-region radius.
+
+### Arguments
+
+* `nlp::AbstractDiagonalQNModel`: a smooth optimization problem
+* `h`: a regularizer such as those defined in ProximalOperators
+* `χ`: a norm used to define the trust region in the form of a regularizer
+* `options::ROSolverOptions`: a structure containing algorithmic parameters
+
+The objective and gradient of `nlp` will be accessed.
+
+In the second form, instead of `nlp`, the user may pass in
+
+* `f` a function such that `f(x)` returns the value of f at x
+* `∇f!` a function to evaluate the gradient in place, i.e., such that `∇f!(g, x)` store ∇f(x) in `g`
+* `x0::AbstractVector`: an initial guess.
+
+### Keyword arguments
+
+#TODO
+
+### Return values
+
+#TODO
+"""
+function TRDH(
+  nlp::AbstractDiagonalQNModel{T, V},
+  h,
+  χ,
+  options::ROSolverOptions{T};
+  kwargs...,
+) where {T, V}
+  kwargs_dict = Dict(kwargs...)
+  selected = pop!(kwargs_dict, :selected, 1:(nlp.meta.nvar))
+  x0 = pop!(kwargs_dict, :x0, nlp.meta.x0)
+  reg_nlp = RegularizedNLPModel(nlp, h, selected)
+  stats = TRDH(
+    reg_nlp;
+    x = x0,
+    D = nlp.op,
+    χ = χ,
+    atol = options.ϵa,
+    rtol = options.ϵr,
+    neg_tol = options.neg_tol,
+    verbose = options.verbose,
+    max_iter = options.maxIter,
+    max_time = options.maxTime,
+    reduce_TR = options.reduce_TR,
+    Δk = options.Δk,
+    η1 = options.η1,
+    η2 = options.η2,
+    γ = options.γ,
+    α = options.α,
+    β = options.β,
+    kwargs_dict...,
+  )
+  return stats
+end
+
+function TRDH(
+  f::F,
+  ∇f!::G,
+  h::H,
+  D::DQN,
+  options::ROSolverOptions{R},
+  x0::AbstractVector{R};
+  χ::X = NormLinf(one(R)),
+  selected::AbstractVector{<:Integer} = 1:length(x0),
+  kwargs...,
+) where {R <: Real, F, G, H, DQN <: AbstractDiagonalQuasiNewtonOperator, X}
+  nlp = FirstOrderModel(f, ∇f!, x0)
+  reg_nlp = RegularizedNLPModel(nlp, h, selected)
+  stats = TRDH(
+    reg_nlp;
+    x = x0,
+    D = D,
+    χ = χ,
+    atol = options.ϵa,
+    rtol = options.ϵr,
+    neg_tol = options.neg_tol,
+    verbose = options.verbose,
+    max_iter = options.maxIter,
+    max_time = options.maxTime,
+    reduce_TR = options.reduce_TR,
+    Δk = options.Δk,
+    η1 = options.η1,
+    η2 = options.η2,
+    γ = options.γ,
+    α = options.α,
+    β = options.β,
+    kwargs_dict...,
+  )
+  return stats
+end
+
+function TRDH(reg_nlp::AbstractRegularizedNLPModel{T, V}; kwargs...) where {T, V}
+  kwargs_dict = Dict(kwargs...)
+  D = pop!(kwargs_dict, :D, nothing)
+  χ = pop!(kwargs_dict, :χ, NormLinf(one(T)))
+  solver = TRDHSolver(reg_nlp, D = D, χ = χ)
+  stats = RegularizedExecutionStats(reg_nlp)
+  solve!(solver, reg_nlp, stats; kwargs_dict...)
+  return stats
+end
+
 function SolverCore.solve!(
   solver::TRDHSolver{T, G, V},
   reg_nlp::AbstractRegularizedNLPModel{T, V},
   stats::GenericExecutionStats{T, V};
   callback = (args...) -> nothing,
   x::V = reg_nlp.model.meta.x0,
-  #χ = NormLinf(one(T)),
   atol::T = √eps(T),
   rtol::T = √eps(T),
   neg_tol::T = eps(T)^(1 / 4),
@@ -397,89 +519,6 @@ function SolverCore.solve!(
   end
 end
 
-"""
-    TRDH(nlp, h, χ, options; kwargs...)
-    TRDH(f, ∇f!, h, options, x0)
-
-A trust-region method with diagonal Hessian approximation for the problem
-
-    min f(x) + h(x)
-
-where f: ℝⁿ → ℝ has a Lipschitz-continuous Jacobian, and h: ℝⁿ → ℝ is
-lower semi-continuous and proper.
-
-About each iterate xₖ, a step sₖ is computed as an approximate solution of
-
-    min  φ(s; xₖ) + ψ(s; xₖ)  subject to  ‖s‖ ≤ Δₖ
-
-where φ(s ; xₖ) = f(xₖ) + ∇f(xₖ)ᵀs + ½ sᵀ Dₖ s  is a quadratic approximation of f about xₖ,
-ψ(s; xₖ) = h(xₖ + s), ‖⋅‖ is a user-defined norm, Dₖ is a diagonal Hessian approximation
-and Δₖ > 0 is the trust-region radius.
-
-### Arguments
-
-* `nlp::AbstractDiagonalQNModel`: a smooth optimization problem
-* `h`: a regularizer such as those defined in ProximalOperators
-* `χ`: a norm used to define the trust region in the form of a regularizer
-* `options::ROSolverOptions`: a structure containing algorithmic parameters
-
-The objective and gradient of `nlp` will be accessed.
-
-In the second form, instead of `nlp`, the user may pass in
-
-* `f` a function such that `f(x)` returns the value of f at x
-* `∇f!` a function to evaluate the gradient in place, i.e., such that `∇f!(g, x)` store ∇f(x) in `g`
-* `x0::AbstractVector`: an initial guess.
-
-### Keyword arguments
-
-* `x0::AbstractVector`: an initial guess (default: `nlp.meta.x0`)
-* `selected::AbstractVector{<:Integer}`: (default `1:f.meta.nvar`)
-
-### Return values
-
-* `xk`: the final iterate
-* `Fobj_hist`: an array with the history of values of the smooth objective
-* `Hobj_hist`: an array with the history of values of the nonsmooth objective
-* `Complex_hist`: an array with the history of number of inner iterations.
-"""
-function TRDH(
-  nlp::AbstractDiagonalQNModel{R, S},
-  h,
-  χ,
-  options::ROSolverOptions{R};
-  kwargs...,
-) where {R <: Real, S}
-  kwargs_dict = Dict(kwargs...)
-  x0 = pop!(kwargs_dict, :x0, nlp.meta.x0)
-  xk, k, outdict = TRDH(
-    x -> obj(nlp, x),
-    (g, x) -> grad!(nlp, x, g),
-    h,
-    hess_op(nlp, x0),
-    options,
-    x0;
-    χ = χ,
-    l_bound = nlp.meta.lvar,
-    u_bound = nlp.meta.uvar,
-    kwargs...,
-  )
-  sqrt_ξ_νInv = outdict[:sqrt_ξ_νInv]
-  stats = GenericExecutionStats(nlp)
-  set_status!(stats, outdict[:status])
-  set_solution!(stats, xk)
-  set_objective!(stats, outdict[:fk] + outdict[:hk])
-  set_residuals!(stats, zero(eltype(xk)), sqrt_ξ_νInv)
-  set_iter!(stats, k)
-  set_time!(stats, outdict[:elapsed_time])
-  set_solver_specific!(stats, :radius, outdict[:radius])
-  set_solver_specific!(stats, :Fhist, outdict[:Fhist])
-  set_solver_specific!(stats, :Hhist, outdict[:Hhist])
-  set_solver_specific!(stats, :NonSmooth, outdict[:NonSmooth])
-  set_solver_specific!(stats, :SubsolverCounter, outdict[:Chist])
-  return stats
-end
-
 # update l_bound_k and u_bound_k
 function update_bounds!(l_bound_k, u_bound_k, is_subsolver, l_bound, u_bound, xk, Δ)
   if is_subsolver
@@ -489,279 +528,4 @@ function update_bounds!(l_bound_k, u_bound_k, is_subsolver, l_bound, u_bound, xk
     @. l_bound_k = max(-Δ, l_bound - xk)
     @. u_bound_k = min(Δ, u_bound - xk)
   end
-end
-
-function TRDH(
-  f::F,
-  ∇f!::G,
-  h::H,
-  D::DQN,
-  options::ROSolverOptions{R},
-  x0::AbstractVector{R};
-  χ::X = NormLinf(one(R)),
-  selected::AbstractVector{<:Integer} = 1:length(x0),
-  kwargs...,
-) where {R <: Real, F, G, H, DQN <: AbstractDiagonalQuasiNewtonOperator, X}
-  start_time = time()
-  elapsed_time = 0.0
-  ϵ = options.ϵa
-  ϵr = options.ϵr
-  Δk = options.Δk
-  neg_tol = options.neg_tol
-  verbose = options.verbose
-  maxIter = options.maxIter
-  maxTime = options.maxTime
-  η1 = options.η1
-  η2 = options.η2
-  γ = options.γ
-  α = options.α
-  β = options.β
-  reduce_TR = options.reduce_TR
-
-  local l_bound, u_bound
-  has_bnds = false
-  kw_keys = keys(kwargs)
-  if :l_bound in kw_keys
-    l_bound = kwargs[:l_bound]
-    has_bnds = has_bnds || any(l_bound .!= R(-Inf))
-  end
-  if :u_bound in kw_keys
-    u_bound = kwargs[:u_bound]
-    has_bnds = has_bnds || any(u_bound .!= R(Inf))
-  end
-
-  if verbose == 0
-    ptf = Inf
-  elseif verbose == 1
-    ptf = round(maxIter / 10)
-  elseif verbose == 2
-    ptf = round(maxIter / 100)
-  else
-    ptf = 1
-  end
-
-  # initialize parameters
-  xk = copy(x0)
-  hk = h(xk[selected])
-  if hk == Inf
-    verbose > 0 && @info "TRDH: finding initial guess where nonsmooth term is finite"
-    prox!(xk, h, x0, one(eltype(x0)))
-    hk = h(xk[selected])
-    hk < Inf || error("prox computation must be erroneous")
-    verbose > 0 && @debug "TRDH: found point where h has value" hk
-  end
-  hk == -Inf && error("nonsmooth term is not proper")
-
-  xkn = similar(xk)
-  s = zero(xk)
-  l_bound_k = similar(xk)
-  u_bound_k = similar(xk)
-  is_subsolver = h isa ShiftedProximableFunction # case TRDH is used as a subsolver
-  if is_subsolver
-    ψ = shifted(h, xk)
-    @assert !has_bnds
-    l_bound = copy(ψ.l)
-    u_bound = copy(ψ.u)
-    @. l_bound_k = max(xk - Δk, l_bound)
-    @. u_bound_k = min(xk + Δk, u_bound)
-    has_bnds = true
-    set_bounds!(ψ, l_bound_k, u_bound_k)
-  else
-    if has_bnds
-      @. l_bound_k = max(-Δk, l_bound - xk)
-      @. u_bound_k = min(Δk, u_bound - xk)
-      ψ = shifted(h, xk, l_bound_k, u_bound_k, selected)
-    else
-      ψ = shifted(h, xk, Δk, χ)
-    end
-  end
-
-  Fobj_hist = zeros(maxIter)
-  Hobj_hist = zeros(maxIter)
-  Complex_hist = zeros(Int, maxIter)
-  if verbose > 0
-    #! format: off
-    if reduce_TR
-      @info @sprintf "%6s %8s %8s %7s %7s %8s %7s %7s %7s %7s %1s" "outer" "f(x)" "h(x)" "√(ξ1/ν)" "√ξ" "ρ" "Δ" "‖x‖" "‖s‖" "‖Dₖ‖" "TRDH"
-    else
-      @info @sprintf "%6s %8s %8s %7s %8s %7s %7s %7s %7s %1s" "outer" "f(x)" "h(x)" "√(ξ/ν)" "ρ" "Δ" "‖x‖" "‖s‖" "‖Dₖ‖" "TRDH"
-    end
-    #! format: off
-  end
-
-  local ξ1
-  local ξ
-  k = 0
-
-  fk = f(xk)
-  ∇fk = similar(xk)
-  ∇f!(∇fk, xk)
-  ∇fk⁻ = copy(∇fk)
-  DNorm = norm(D.d, Inf)
-  ν = (α * Δk)/(DNorm + one(R))
-  mν∇fk = -ν .* ∇fk
-  sqrt_ξ_νInv = one(R)
-
-  optimal = false
-  tired = maxIter > 0 && k ≥ maxIter || elapsed_time > maxTime
-
-  while !(optimal || tired)
-    k = k + 1
-    elapsed_time = time() - start_time
-    Fobj_hist[k] = fk
-    Hobj_hist[k] = hk
-
-    # model for prox-gradient step to update Δk if ||s|| is too small and ξ1
-    φ1(d) = ∇fk' * d
-    mk1(d) = φ1(d) + ψ(d)
-
-    if reduce_TR
-      prox!(s, ψ, mν∇fk, ν)
-      Complex_hist[k] += 1
-      ξ1 = hk - mk1(s) + max(1, abs(hk)) * 10 * eps()
-      sqrt_ξ_νInv = ξ1 ≥ 0 ? sqrt(ξ1 / ν) : sqrt(-ξ1 / ν)
-
-      if ξ1 ≥ 0 && k == 1
-        ϵ += ϵr * sqrt_ξ_νInv  # make stopping test absolute and relative
-      end
-
-      if (ξ1 < 0 && sqrt_ξ_νInv ≤ neg_tol) || (ξ1 ≥ 0 && sqrt_ξ_νInv < ϵ)
-        # the current xk is approximately first-order stationary
-        optimal = true
-        continue
-      end
-
-      ξ1 > 0 || error("TR: first prox-gradient step should produce a decrease but ξ1 = $(ξ1)")
-    end
-
-    Δ_effective = reduce_TR ? min(β * χ(s), Δk) : Δk
-    # update radius
-    if has_bnds
-      update_bounds!(l_bound_k, u_bound_k, is_subsolver, l_bound, u_bound, xk, Δ_effective)
-      set_bounds!(ψ, l_bound_k, u_bound_k)
-    else
-      set_radius!(ψ, Δ_effective)
-    end
-
-    # model with diagonal hessian
-    φ(d) = ∇fk' * d + (d' * (D.d .* d)) / 2
-    mk(d) = φ(d) + ψ(d)
-
-    iprox!(s, ψ, ∇fk, D)
-
-    sNorm = χ(s)
-    xkn .= xk .+ s
-    fkn = f(xkn)
-    hkn = h(xkn[selected])
-    hkn == -Inf && error("nonsmooth term is not proper")
-
-    Δobj = fk + hk - (fkn + hkn) + max(1, abs(fk + hk)) * 10 * eps()
-    ξ = hk - mk(s) + max(1, abs(hk)) * 10 * eps()
-
-    if !reduce_TR
-
-      sqrt_ξ_νInv = ξ ≥ 0 ? sqrt(ξ / ν) : sqrt(-ξ / ν)
-      if ξ ≥ 0 && k == 1
-        ϵ += ϵr * sqrt_ξ_νInv  # make stopping test absolute and relative
-      end
-
-      if (ξ < 0 && sqrt_ξ_νInv ≤ neg_tol) || (ξ ≥ 0 && sqrt_ξ_νInv < ϵ)
-        # the current xk is approximately first-order stationary
-        optimal = true
-        continue
-      end
-    end
-
-    if (ξ ≤ 0 || isnan(ξ))
-      error("TRDH: failed to compute a step: ξ = $ξ")
-    end
-
-    ρk = Δobj / ξ
-
-    TR_stat = (η2 ≤ ρk < Inf) ? "↗" : (ρk < η1 ? "↘" : "=")
-
-    if (verbose > 0) && (k % ptf == 0)
-      #! format: off
-      if reduce_TR
-        @info @sprintf "%6d %8.1e %8.1e %7.1e %7.1e %8.1e %7.1e %7.1e %7.1e %7.1e %1s" k fk hk sqrt_ξ_νInv sqrt(ξ) ρk Δk χ(xk) sNorm norm(D.d) TR_stat
-      else
-        @info @sprintf "%6d %8.1e %8.1e %7.1e %8.1e %7.1e %7.1e %7.1e %7.1e %1s" k fk hk sqrt_ξ_νInv ρk Δk χ(xk) sNorm norm(D.d) TR_stat
-      end
-      #! format: on
-    end
-
-    if η2 ≤ ρk < Inf
-      Δk = max(Δk, γ * sNorm)
-      !has_bnds && set_radius!(ψ, Δk)
-    end
-
-    if η1 ≤ ρk < Inf
-      xk .= xkn
-      has_bnds && update_bounds!(l_bound_k, u_bound_k, is_subsolver, l_bound, u_bound, xk, Δk)
-      has_bnds && set_bounds!(ψ, l_bound_k, u_bound_k)
-      #update functions
-      fk = fkn
-      hk = hkn
-      shift!(ψ, xk)
-      ∇f!(∇fk, xk)
-      push!(D, s, ∇fk - ∇fk⁻) # update QN operator
-      DNorm = norm(D.d, Inf)
-      ∇fk⁻ .= ∇fk
-    end
-
-    if ρk < η1 || ρk == Inf
-      Δk = Δk / 2
-      has_bnds && update_bounds!(l_bound_k, u_bound_k, is_subsolver, l_bound, u_bound, xk, Δk)
-      has_bnds ? set_bounds!(ψ, l_bound_k, u_bound_k) : set_radius!(ψ, Δk)
-    end
-
-    ν = reduce_TR ? (α * Δk)/(DNorm + one(R)) : α / (DNorm + one(R))
-    mν∇fk .= -ν .* ∇fk
-
-    tired = k ≥ maxIter || elapsed_time > maxTime
-  end
-
-  if verbose > 0
-    if k == 1
-      @info @sprintf "%6d %8s %8.1e %8.1e" k "" fk hk
-    elseif optimal
-      #! format: off
-      if reduce_TR
-        @info @sprintf "%6d %8.1e %8.1e %7.1e %7.1e %8s %7.1e %7.1e %7.1e %7.1e" k fk hk sqrt_ξ_νInv sqrt(ξ1) "" Δk χ(xk) χ(s) norm(D.d)
-        #! format: on
-        @info "TRDH: terminating with √(ξ1/ν) = $(sqrt_ξ_νInv)"
-      else
-        #! format: off
-        @info @sprintf "%6d %8.1e %8.1e %7.1e %8s %7.1e %7.1e %7.1e %7.1e" k fk hk sqrt_ξ_νInv "" Δk χ(xk) χ(s) norm(D.d)
-        #! format: on
-        @info "TRDH: terminating with √(ξ/ν) = $(sqrt_ξ_νInv)"
-      end
-    end
-  end
-
-  !reduce_TR && (ξ1 = ξ) # for output dict
-
-  status = if optimal
-    :first_order
-  elseif elapsed_time > maxTime
-    :max_time
-  elseif tired
-    :max_iter
-  else
-    :exception
-  end
-  outdict = Dict(
-    :Fhist => Fobj_hist[1:k],
-    :Hhist => Hobj_hist[1:k],
-    :Chist => Complex_hist[1:k],
-    :NonSmooth => h,
-    :status => status,
-    :fk => fk,
-    :hk => hk,
-    :sqrt_ξ_νInv => sqrt_ξ_νInv,
-    :elapsed_time => elapsed_time,
-    :radius => Δk,
-  )
-
-  return xk, k, outdict
 end

--- a/src/TRDH_alg.jl
+++ b/src/TRDH_alg.jl
@@ -226,7 +226,8 @@ function TRDH(
     η2 = options.η2,
     γ = options.γ,
     α = options.α,
-    β = options.β
+    β = options.β,
+    kwargs...
   )
   return stats
 end

--- a/src/TRDH_alg.jl
+++ b/src/TRDH_alg.jl
@@ -55,7 +55,7 @@ function TRDHSolver(
     @. l_bound_k = max(xk - one(T), l_bound)
     @. u_bound_k = min(xk + one(T), u_bound)
     has_bnds = true
-    ψ = shifted(reg_nlp.h, xk, l_bound_k, u_bound_k, reg_nlp.selected) #fails
+    set_bounds!(ψ, l_bound_k, u_bound_k)
   else
     if has_bnds
       @. l_bound_k = max(-one(T), l_bound - xk)
@@ -161,7 +161,8 @@ function TRDH(
     η2 = options.η2,
     γ = options.γ,
     α = options.α,
-    β = options.β
+    β = options.β,
+    kwargs_dict...
   )
   return stats
 end
@@ -196,8 +197,7 @@ function TRDH(
     η2 = options.η2,
     γ = options.γ,
     α = options.α,
-    β = options.β,
-    kwargs_dict...,
+    β = options.β
   )
   return stats
 end
@@ -516,6 +516,10 @@ function SolverCore.solve!(
       )
     @info "TRDH: terminating with √(ξ/ν) = $(sqrt_ξ_νInv)"
   end
+
+  set_solution!(stats, xk)
+
+  return stats
 end
 
 # update l_bound_k and u_bound_k

--- a/src/TRDH_alg.jl
+++ b/src/TRDH_alg.jl
@@ -58,8 +58,8 @@ function TRDHSolver(
     set_bounds!(ψ, l_bound_k, u_bound_k)
   else
     if has_bnds
-      @. l_bound_k = max(-one(T), l_bound - xk)
-      @. u_bound_k = min(one(T), u_bound - xk)
+      @. l_bound_k = max(-one(T), l_bound - x0)
+      @. u_bound_k = min(one(T), u_bound - x0)
       ψ = shifted(reg_nlp.h, xk, l_bound_k, u_bound_k, reg_nlp.selected)
     else
       ψ = shifted(reg_nlp.h, xk, one(T), χ)
@@ -229,7 +229,7 @@ function TRDH(
     β = options.β,
     kwargs...
   )
-  return stats
+  return stats.solution, stats.iter, stats
 end
 
 function TRDH(reg_nlp::AbstractRegularizedNLPModel{T, V}; kwargs...) where {T, V}

--- a/src/TRDH_alg.jl
+++ b/src/TRDH_alg.jl
@@ -52,8 +52,8 @@ function TRDHSolver(
     @assert !has_bnds
     l_bound = copy(ψ.l)
     u_bound = copy(ψ.u)
-    @. l_bound_k = max(xk - one(T), l_bound)
-    @. u_bound_k = min(xk + one(T), u_bound)
+    @. l_bound_k = max(x0 - one(T), l_bound)
+    @. u_bound_k = min(x0 + one(T), u_bound)
     has_bnds = true
     set_bounds!(ψ, l_bound_k, u_bound_k)
   else

--- a/src/TRDH_alg.jl
+++ b/src/TRDH_alg.jl
@@ -55,12 +55,12 @@ function TRDHSolver(
     @. l_bound_k = max(xk - one(T), l_bound)
     @. u_bound_k = min(xk + one(T), u_bound)
     has_bnds = true
-    set_bounds!(ψ, l_bound_k, u_bound_k)
+    ψ = shifted(reg_nlp.h, xk, l_bound_k, u_bound_k, reg_nlp.selected) #fails
   else
     if has_bnds
       @. l_bound_k = max(-one(T), l_bound - xk)
       @. u_bound_k = min(one(T), u_bound - xk)
-      ψ = shifted(reg_nlp.h, xk, l_bound_k, u_bound_k, selected)
+      ψ = shifted(reg_nlp.h, xk, l_bound_k, u_bound_k, reg_nlp.selected)
     else
       ψ = shifted(reg_nlp.h, xk, one(T), χ)
     end
@@ -161,8 +161,7 @@ function TRDH(
     η2 = options.η2,
     γ = options.γ,
     α = options.α,
-    β = options.β,
-    kwargs_dict...,
+    β = options.β
   )
   return stats
 end

--- a/src/TR_alg.jl
+++ b/src/TR_alg.jl
@@ -29,8 +29,8 @@ mutable struct TRSolver{
 end
 
 function TRSolver(
-  reg_nlp::AbstractRegularizedNLPModel{T, V},
-  χ::X;
+  reg_nlp::AbstractRegularizedNLPModel{T, V};
+  χ::X = NormLinf(one(T)),
   subsolver = R2Solver
 ) where {T, V, X}
   x0 = reg_nlp.model.meta.x0
@@ -138,245 +138,40 @@ function TR(
   subsolver = R2,
   subsolver_options = ROSolverOptions(ϵa = options.ϵa),
   selected::AbstractVector{<:Integer} = 1:(f.meta.nvar),
+  kwargs...
 ) where {H, X, R}
-  start_time = time()
-  elapsed_time = 0.0
-  # initialize passed options
-  ϵ = options.ϵa
-  ϵ_subsolver = subsolver_options.ϵa
-  ϵr = options.ϵr
-  Δk = options.Δk
-  verbose = options.verbose
-  maxIter = options.maxIter
-  maxTime = options.maxTime
-  η1 = options.η1
-  η2 = options.η2
-  γ = options.γ
-  α = options.α
-  θ = options.θ
-  β = options.β
+  reg_nlp = RegularizedNLPModel(f, h, selected)
+  stats = TR(
+    reg_nlp;
+    x = x0,
+    atol = options.ϵa,
+    sub_atol = subsolver_options.ϵa,
+    rtol = options.ϵr,
+    neg_tol = options.neg_tol,
+    verbose = options.verbose,
+    max_iter = options.maxIter,
+    max_time = options.maxTime,
+    Δk = options.Δk,
+    η1 = options.η1,
+    η2 = options.η2,
+    γ = options.γ,
+    α = options.α,
+    β = options.β,
+    kwargs...
+  )
+  return stats
+end
 
-  # store initial values of the subsolver_options fields that will be modified
-  ν_subsolver = subsolver_options.ν
-  ϵa_subsolver = subsolver_options.ϵa
-  Δk_subsolver = subsolver_options.Δk
-
-  local l_bound, u_bound
-  if has_bounds(f) || subsolver == TRDH
-    l_bound = f.meta.lvar
-    u_bound = f.meta.uvar
-  end
-
-  if verbose == 0
-    ptf = Inf
-  elseif verbose == 1
-    ptf = round(maxIter / 10)
-  elseif verbose == 2
-    ptf = round(maxIter / 100)
-  else
-    ptf = 1
-  end
-
-  # initialize parameters
-  xk = copy(x0)
-  hk = h(xk[selected])
-  if hk == Inf
-    verbose > 0 && @info "TR: finding initial guess where nonsmooth term is finite"
-    prox!(xk, h, x0, one(eltype(x0)))
-    hk = h(xk[selected])
-    hk < Inf || error("prox computation must be erroneous")
-    verbose > 0 && @debug "TR: found point where h has value" hk
-  end
-  hk == -Inf && error("nonsmooth term is not proper")
-
-  xkn = similar(xk)
-  s = zero(xk)
-  ψ =
-    (has_bounds(f) || subsolver == TRDH) ?
-    shifted(h, xk, max.(-Δk, l_bound - xk), min.(Δk, u_bound - xk), selected) :
-    shifted(h, xk, Δk, χ)
-
-  Fobj_hist = zeros(maxIter)
-  Hobj_hist = zeros(maxIter)
-  Complex_hist = zeros(Int, maxIter)
-  if verbose > 0
-    #! format: off
-    @info @sprintf "%6s %8s %8s %8s %7s %7s %8s %7s %7s %7s %7s %1s" "outer" "inner" "f(x)" "h(x)" "√(ξ1/ν)" "√ξ" "ρ" "Δ" "‖x‖" "‖s‖" "‖Bₖ‖" "TR"
-    #! format: on
-  end
-
-  local ξ1
-  k = 0
-
-  fk = obj(f, xk)
-  ∇fk = grad(f, xk)
-  ∇fk⁻ = copy(∇fk)
-
-  quasiNewtTest = isa(f, QuasiNewtonModel)
-  Bk = hess_op(f, xk)
-
-  λmax, found_λ = opnorm(Bk)
-  found_λ || error("operator norm computation failed")
-  α⁻¹Δ⁻¹ = 1 / (α * Δk)
-  ν = 1 / (α⁻¹Δ⁻¹ + λmax * (α⁻¹Δ⁻¹ + 1))
-  sqrt_ξ1_νInv = one(R)
-
-  optimal = false
-  tired = k ≥ maxIter || elapsed_time > maxTime
-
-  while !(optimal || tired)
-    k = k + 1
-    elapsed_time = time() - start_time
-    Fobj_hist[k] = fk
-    Hobj_hist[k] = hk
-
-    # model for first prox-gradient step and ξ1
-    φ1(d) = ∇fk' * d
-    mk1(d) = φ1(d) + ψ(d)
-
-    # model for subsequent prox-gradient steps and ξ
-    φ(d) = (d' * (Bk * d)) / 2 + ∇fk' * d
-
-    ∇φ!(g, d) = begin
-      mul!(g, Bk, d)
-      g .+= ∇fk
-      g
-    end
-
-    mk(d) = φ(d) + ψ(d)
-
-    # Take first proximal gradient step s1 and see if current xk is nearly stationary.
-    # s1 minimizes φ1(s) + ‖s‖² / 2 / ν + ψ(s) ⟺ s1 ∈ prox{νψ}(-ν∇φ1(0)).
-    prox!(s, ψ, -ν * ∇fk, ν)
-    ξ1 = hk - mk1(s) + max(1, abs(hk)) * 10 * eps()
-    ξ1 > 0 || error("TR: first prox-gradient step should produce a decrease but ξ1 = $(ξ1)")
-    sqrt_ξ1_νInv = sqrt(ξ1 / ν)
-
-    if ξ1 ≥ 0 && k == 1
-      ϵ_increment = ϵr * sqrt_ξ1_νInv
-      ϵ += ϵ_increment  # make stopping test absolute and relative
-      ϵ_subsolver += ϵ_increment
-    end
-
-    if sqrt_ξ1_νInv < ϵ
-      # the current xk is approximately first-order stationary
-      optimal = true
-      continue
-    end
-
-    subsolver_options.ϵa = k == 2 ? 1.0e-5 : max(ϵ_subsolver, min(1e-2, sqrt_ξ1_νInv))
-    ∆_effective = min(β * χ(s), Δk)
-    (has_bounds(f) || subsolver == TRDH) ?
-    set_bounds!(ψ, max.(-∆_effective, l_bound - xk), min.(∆_effective, u_bound - xk)) :
-    set_radius!(ψ, ∆_effective)
-    subsolver_options.Δk = ∆_effective / 10
-    subsolver_options.ν = ν
-    subsolver_args = subsolver == TRDH ? (SpectralGradient(1 / ν, f.meta.nvar),) : ()
-
-    stats = subsolver(φ, ∇φ!, ψ, subsolver_args..., subsolver_options, s)
-
-    s = stats.solution
-    iter = stats.iter
-
-    # restore initial values of subsolver_options here so that it is not modified
-    # if there is an error
-    subsolver_options.ν = ν_subsolver
-    subsolver_options.ϵa = ϵa_subsolver
-    subsolver_options.Δk = Δk_subsolver
-
-    Complex_hist[k] = 1
-
-    sNorm = χ(s)
-    xkn .= xk .+ s
-    fkn = obj(f, xkn)
-    hkn = h(xkn[selected])
-    hkn == -Inf && error("nonsmooth term is not proper")
-
-    Δobj = fk + hk - (fkn + hkn) + max(1, abs(fk + hk)) * 10 * eps()
-    ξ = hk - mk(s) + max(1, abs(hk)) * 10 * eps()
-
-    if (ξ ≤ 0 || isnan(ξ))
-      error("TR: failed to compute a step: ξ = $ξ")
-    end
-
-    ρk = Δobj / ξ
-
-    TR_stat = (η2 ≤ ρk < Inf) ? "↗" : (ρk < η1 ? "↘" : "=")
-
-    if (verbose > 0) && (k % ptf == 0)
-      #! format: off
-      @info @sprintf "%6d %8d %8.1e %8.1e %7.1e %7.1e %8.1e %7.1e %7.1e %7.1e %7.1e %1s" k iter fk hk sqrt_ξ1_νInv sqrt(ξ) ρk ∆_effective χ(xk) sNorm λmax TR_stat
-      #! format: on
-    end
-
-    if η2 ≤ ρk < Inf
-      Δk = max(Δk, γ * sNorm)
-      !(has_bounds(f) || subsolver == TRDH) && set_radius!(ψ, Δk)
-    end
-
-    if η1 ≤ ρk < Inf
-      xk .= xkn
-      (has_bounds(f) || subsolver == TRDH) &&
-        set_bounds!(ψ, max.(-Δk, l_bound - xk), min.(Δk, u_bound - xk))
-
-      #update functions
-      fk = fkn
-      hk = hkn
-      shift!(ψ, xk)
-      ∇fk = grad(f, xk)
-      # grad!(f, xk, ∇fk)
-      if quasiNewtTest
-        push!(f, s, ∇fk - ∇fk⁻)
-      end
-      Bk = hess_op(f, xk)
-      λmax, found_λ = opnorm(Bk)
-      found_λ || error("operator norm computation failed")
-      ∇fk⁻ .= ∇fk
-    end
-
-    if ρk < η1 || ρk == Inf
-      Δk = Δk / 2
-      (has_bounds(f) || subsolver == TRDH) ?
-      set_bounds!(ψ, max.(-Δk, l_bound - xk), min.(Δk, u_bound - xk)) : set_radius!(ψ, Δk)
-    end
-    α⁻¹Δ⁻¹ = 1 / (α * Δk)
-    ν = 1 / (α⁻¹Δ⁻¹ + λmax * (α⁻¹Δ⁻¹ + 1))
-    tired = k ≥ maxIter || elapsed_time > maxTime
-  end
-
-  if verbose > 0
-    if k == 1
-      @info @sprintf "%6d %8s %8.1e %8.1e" k "" fk hk
-    elseif optimal
-      #! format: off
-      @info @sprintf "%6d %8d %8.1e %8.1e %7.1e %7.1e %8s %7.1e %7.1e %7.1e %7.1e" k 1 fk hk sqrt_ξ1_νInv sqrt(ξ1) "" Δk χ(xk) χ(s) λmax
-      #! format: on
-      @info "TR: terminating with √(ξ1/ν) = $(sqrt_ξ1_νInv)"
-    end
-  end
-
-  status = if optimal
-    :first_order
-  elseif elapsed_time > maxTime
-    :max_time
-  elseif tired
-    :max_iter
-  else
-    :exception
-  end
-
-  stats = GenericExecutionStats(f)
-  set_status!(stats, status)
-  set_solution!(stats, xk)
-  set_objective!(stats, fk + hk)
-  set_residuals!(stats, zero(eltype(xk)), sqrt_ξ1_νInv)
-  set_iter!(stats, k)
-  set_time!(stats, elapsed_time)
-  set_solver_specific!(stats, :radius, Δk)
-  set_solver_specific!(stats, :Fhist, Fobj_hist[1:k])
-  set_solver_specific!(stats, :Hhist, Hobj_hist[1:k])
-  set_solver_specific!(stats, :NonSmooth, h)
-  set_solver_specific!(stats, :SubsolverCounter, Complex_hist[1:k])
+function TR(
+  reg_nlp::AbstractRegularizedNLPModel{T, V};
+  kwargs...
+) where{T, V}
+  kwargs_dict = Dict(kwargs...)
+  subsolver = pop!(kwargs_dict, :subsolver, R2Solver)
+  χ = pop!(kwargs_dict, :χ, NormLinf(one(T)))
+  solver = TRSolver(reg_nlp, subsolver = subsolver, χ = χ)
+  stats = RegularizedExecutionStats(reg_nlp)
+  solve!(solver, reg_nlp, stats; kwargs_dict...)
   return stats
 end
 
@@ -394,7 +189,6 @@ function SolverCore.solve!(
   max_iter::Int = 10000,
   max_time::Float64 = 30.0,
   max_eval::Int = -1,
-  reduce_TR::Bool = true,
   Δk::T = T(1),
   η1::T = √√eps(T),
   η2::T = T(0.9),

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,14 +25,7 @@ for (mod, mod_name) ∈ ((x -> x, "exact"), (LSR1Model, "lsr1"), (LBFGSModel, "l
         out = solver(mod(bpdn), h, args..., options, x0 = x0)
         @test typeof(out.solution) == typeof(bpdn.meta.x0)
         @test length(out.solution) == bpdn.meta.nvar
-        @test typeof(out.solver_specific[:Fhist]) == typeof(out.solution)
-        @test typeof(out.solver_specific[:Hhist]) == typeof(out.solution)
-        @test typeof(out.solver_specific[:SubsolverCounter]) == Array{Int, 1}
         @test typeof(out.dual_feas) == eltype(out.solution)
-        @test length(out.solver_specific[:Fhist]) == length(out.solver_specific[:Hhist])
-        @test length(out.solver_specific[:Fhist]) == length(out.solver_specific[:SubsolverCounter])
-        @test obj(bpdn, out.solution) == out.solver_specific[:Fhist][end]
-        @test h(out.solution) == out.solver_specific[:Hhist][end]
         @test out.status == :first_order
       end
     end
@@ -66,15 +59,7 @@ for (mod, mod_name) ∈ ((LSR1Model, "lsr1"), (LBFGSModel, "lbfgs"))
       TR_out = TR(mod(bpdn), h, NormL2(1.0), options, x0 = x0)
       @test typeof(TR_out.solution) == typeof(bpdn.meta.x0)
       @test length(TR_out.solution) == bpdn.meta.nvar
-      @test typeof(TR_out.solver_specific[:Fhist]) == typeof(TR_out.solution)
-      @test typeof(TR_out.solver_specific[:Hhist]) == typeof(TR_out.solution)
-      @test typeof(TR_out.solver_specific[:SubsolverCounter]) == Array{Int, 1}
       @test typeof(TR_out.dual_feas) == eltype(TR_out.solution)
-      @test length(TR_out.solver_specific[:Fhist]) == length(TR_out.solver_specific[:Hhist])
-      @test length(TR_out.solver_specific[:Fhist]) ==
-            length(TR_out.solver_specific[:SubsolverCounter])
-      @test obj(bpdn, TR_out.solution) == TR_out.solver_specific[:Fhist][end]
-      @test h(TR_out.solution) == TR_out.solver_specific[:Hhist][end]
       @test TR_out.status == :first_order
     end
   end

--- a/test/test_allocs.jl
+++ b/test/test_allocs.jl
@@ -42,17 +42,20 @@ end
 # Test non allocating solve!
 @testset "allocs" begin
   for (h, h_name) ∈ ((NormL0(λ), "l0"),)
-    for (solver, solver_name) ∈ ((:R2Solver, "R2"), (:R2DHSolver, "R2DH"), (:R2NSolver, "R2N"))
+    for (solver, solver_name) ∈ ((:R2Solver, "R2"), (:R2DHSolver, "R2DH"), (:R2NSolver, "R2N"), (:TRDHSolver, "TRDH"), (:TRSolver, "TR"))
       @testset "$(solver_name)" begin
-        solver_name == "R2N" && continue #FIXME
+        (solver_name == "R2N" || solver_name == "TR") && continue #FIXME
         reg_nlp = RegularizedNLPModel(LBFGSModel(bpdn), h)
         solver = eval(solver)(reg_nlp)
         stats = RegularizedExecutionStats(reg_nlp)
-        solver_name == "R2" &&
-          @test @wrappedallocs(solve!(solver, reg_nlp, stats, ν = 1.0, atol = 1e-6, rtol = 1e-6)) ==
-                0
+        solver_name == "R2" && @test @wrappedallocs(
+          solve!(solver, reg_nlp, stats, ν = 1.0, atol = 1e-6, rtol = 1e-6)
+        ) == 0
         solver_name == "R2DH" && @test @wrappedallocs(
           solve!(solver, reg_nlp, stats, σk = 1.0, atol = 1e-6, rtol = 1e-6)
+        ) == 0
+        solver_name == "TRDH" && @test @wrappedallocs(
+          solve!(solver, reg_nlp, stats, atol = 1e-6, rtol = 1e-6)
         ) == 0
         @test stats.status == :first_order
       end

--- a/test/test_bounds.jl
+++ b/test/test_bounds.jl
@@ -15,14 +15,7 @@ for (mod, mod_name) ∈ ((x -> x, "exact"), (LSR1Model, "lsr1"), (LBFGSModel, "l
         out = solver(mod(bpdn2), h, args..., options; x0 = x0)
         @test typeof(out.solution) == typeof(bpdn2.meta.x0)
         @test length(out.solution) == bpdn2.meta.nvar
-        @test typeof(out.solver_specific[:Fhist]) == typeof(out.solution)
-        @test typeof(out.solver_specific[:Hhist]) == typeof(out.solution)
-        @test typeof(out.solver_specific[:SubsolverCounter]) == Array{Int, 1}
         @test typeof(out.dual_feas) == eltype(out.solution)
-        @test length(out.solver_specific[:Fhist]) == length(out.solver_specific[:Hhist])
-        @test length(out.solver_specific[:Fhist]) == length(out.solver_specific[:SubsolverCounter])
-        @test obj(bpdn2, out.solution) == out.solver_specific[:Fhist][end]
-        @test h(out.solution) == out.solver_specific[:Hhist][end]
         @test out.status == :first_order
       end
     end


### PR DESCRIPTION
@dpo did the two solvers in one PR because i couldn't modify `TR` if `TRDH` was not udpated (due to when I use `solve!` in TR to call the subsolver)
Also, a few TODOs in the doc because i am not sure what some parameters mean.
Finally, as in #172, the solvers behaviours remain the same and there are no allocs (there are still for TR since `opnorm` allocates).

cc. @MohamedLaghdafHABIBOULLAH 