### PR TITLE
Use callback docstring for all solvers and solve the bug with the arrow being printed too far with verbose

### DIFF
--- a/src/R2DH.jl
+++ b/src/R2DH.jl
@@ -134,21 +134,7 @@ The algorithm stops either when `√(ξₖ/νₖ) < atol + rtol*√(ξ₀/ν₀)
 The value returned is a `GenericExecutionStats`, see `SolverCore.jl`.
 
 # Callback
-The callback is called at each iteration.
-The expected signature of the callback is `callback(nlp, solver, stats)`, and its output is ignored.
-Changing any of the input arguments will affect the subsequent iterations.
-In particular, setting `stats.status = :user` will stop the algorithm.
-All relevant information should be available in `nlp` and `solver`.
-Notably, you can access, and modify, the following:
-- `solver.xk`: current iterate;
-- `solver.∇fk`: current gradient;
-- `stats`: structure holding the output of the algorithm (`GenericExecutionStats`), which contains, among other things:
-  - `stats.iter`: current iteration counter;
-  - `stats.objective`: current objective function value;
-  - `stats.solver_specific[:smooth_obj]`: current value of the smooth part of the objective function;
-  - `stats.solver_specific[:nonsmooth_obj]`: current value of the nonsmooth part of the objective function;
-  - `stats.status`: current status of the algorithm. Should be `:unknown` unless the algorithm has attained a stopping criterion. Changing this to anything will stop the algorithm, but you should use `:user` to properly indicate the intention;
-  - `stats.elapsed_time`: elapsed time in seconds.
+$(callback_docstring)
 """
 function R2DH(
   nlp::AbstractDiagonalQNModel{T, V},

--- a/src/R2DH.jl
+++ b/src/R2DH.jl
@@ -380,7 +380,7 @@ function SolverCore.solve!(
           σk,
           norm(xk),
           norm(s),
-          (η2 ≤ ρk < Inf) ? "↘" : (ρk < η1 ? "↗" : "="),
+          (η2 ≤ ρk < Inf) ? '↘' : (ρk < η1 ? '↗' : '='),
         ],
         colsep = 1,
       )
@@ -464,7 +464,7 @@ function SolverCore.solve!(
         σk,
         norm(xk),
         norm(s),
-        (η2 ≤ ρk < Inf) ? "↘" : (ρk < η1 ? "↗" : "="),
+        "",
       ],
       colsep = 1,
     )

--- a/src/R2N.jl
+++ b/src/R2N.jl
@@ -142,21 +142,7 @@ The algorithm stops either when `√(ξₖ/νₖ) < atol + rtol*√(ξ₀/ν₀)
 The value returned is a `GenericExecutionStats`, see `SolverCore.jl`.
 
 # Callback
-The callback is called at each iteration.
-The expected signature of the callback is `callback(nlp, solver, stats)`, and its output is ignored.
-Changing any of the input arguments will affect the subsequent iterations.
-In particular, setting `stats.status = :user` will stop the algorithm.
-All relevant information should be available in `nlp` and `solver`.
-Notably, you can access, and modify, the following:
-- `solver.xk`: current iterate;
-- `solver.∇fk`: current gradient;
-- `stats`: structure holding the output of the algorithm (`GenericExecutionStats`), which contains, among other things:
-  - `stats.iter`: current iteration counter;
-  - `stats.objective`: current objective function value;
-  - `stats.solver_specific[:smooth_obj]`: current value of the smooth part of the objective function;
-  - `stats.solver_specific[:nonsmooth_obj]`: current value of the nonsmooth part of the objective function;
-  - `stats.status`: current status of the algorithm. Should be `:unknown` unless the algorithm has attained a stopping criterion. Changing this to anything other than `:unknown` will stop the algorithm, but you should use `:user` to properly indicate the intention;
-  - `stats.elapsed_time`: elapsed time in seconds.
+$(callback_docstring)
 Similarly to the callback, when using a quasi-Newton approximation, two functions, `qn_update_y!(nlp, solver, stats)` and `qn_copy!(nlp, solver, stats)` are called at each update of the approximation.
 Namely, the former computes the `y` vector for which the pair `(s, y)` is pushed into the approximation.
 By default, `y := ∇fk⁻ - ∇fk`.

--- a/src/R2N.jl
+++ b/src/R2N.jl
@@ -411,7 +411,7 @@ function SolverCore.solve!(
           norm(xk),
           norm(s),
           λmax,
-          (η2 ≤ ρk < Inf) ? "↘" : (ρk < η1 ? "↗" : "="),
+          (η2 ≤ ρk < Inf) ? '↘' : (ρk < η1 ? '↗' : '='),
         ],
         colsep = 1,
       )
@@ -504,7 +504,7 @@ function SolverCore.solve!(
         norm(xk),
         norm(s),
         λmax,
-        (η2 ≤ ρk < Inf) ? "↘" : (ρk < η1 ? "↗" : "="),
+        "",
       ],
       colsep = 1,
     )

--- a/src/R2_alg.jl
+++ b/src/R2_alg.jl
@@ -160,21 +160,7 @@ The algorithm stops either when `√(ξₖ/νₖ) < atol + rtol*√(ξ₀/ν₀)
 The value returned is a `GenericExecutionStats`, see `SolverCore.jl`.
 
 # Callback
-The callback is called at each iteration.
-The expected signature of the callback is `callback(nlp, solver, stats)`, and its output is ignored.
-Changing any of the input arguments will affect the subsequent iterations.
-In particular, setting `stats.status = :user` will stop the algorithm.
-All relevant information should be available in `nlp` and `solver`.
-Notably, you can access, and modify, the following:
-- `solver.xk`: current iterate;
-- `solver.∇fk`: current gradient;
-- `stats`: structure holding the output of the algorithm (`GenericExecutionStats`), which contains, among other things:
-  - `stats.iter`: current iteration counter;
-  - `stats.objective`: current objective function value;
-  - `stats.solver_specific[:smooth_obj]`: current value of the smooth part of the objective function
-  - `stats.solver_specific[:nonsmooth_obj]`: current value of the nonsmooth part of the objective function
-  - `stats.status`: current status of the algorithm. Should be `:unknown` unless the algorithm has attained a stopping criterion. Changing this to anything will stop the algorithm, but you should use `:user` to properly indicate the intention.
-  - `stats.elapsed_time`: elapsed time in seconds.
+$(callback_docstring)
 """
 function R2(
   nlp::AbstractNLPModel{R, V},

--- a/src/R2_alg.jl
+++ b/src/R2_alg.jl
@@ -374,7 +374,7 @@ function SolverCore.solve!(
         :σ => "σ",
         :normx => "‖x‖",
         :norms => "‖s‖",
-        :arrow => " ",
+        :arrow => "R2",
       ),
       colsep = 1,
     )
@@ -454,7 +454,7 @@ function SolverCore.solve!(
           σk,
           norm(xk),
           norm(s),
-          (η2 ≤ ρk < Inf) ? "↘" : (ρk < η1 ? "↗" : "="),
+          (η2 ≤ ρk < Inf) ? '↘' : (ρk < η1 ? '↗' : '='),
         ],
         colsep = 1,
       )
@@ -528,7 +528,7 @@ function SolverCore.solve!(
         σk,
         norm(xk),
         norm(s),
-        (η2 ≤ ρk < Inf) ? "↘" : (ρk < η1 ? "↗" : "="),
+        "",
       ],
       colsep = 1,
     )


### PR DESCRIPTION
#231 