### PR TITLE
Add DOI to paper.bib entry

### DIFF
--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -156,5 +156,6 @@
   number        = {1},
   pages         = {293--318},
   year          = {1992},
-  publisher     = {Springer}
+  publisher     = {Springer},
+  doi           = {10.1007/BF01581204}
 }


### PR DESCRIPTION
We forgot to add to the douglas rachford splitting paper.

Causes the editorialbot to fail on check references.