### PR TITLE
Update author list

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,8 +2,8 @@ name = "RegularizedOptimization"
 uuid = "196f2941-2d58-45ba-9f13-43a2532b2fa8"
 author = ["Robert Baraldi <rbaraldi@uw.edu>", 
           "Youssef Diouane <youssef.diouane@polymtl.ca>",
-          "Maxence Gollier <maxence.gollier@polymtl.ca>",
-          "Mohamed Laghdaf Habiboullah <mohamed.habiboullah@polymtl.ca>",
+          "Maxence Gollier <maxence-2.gollier@polymtl.ca>",
+          "Mohamed Laghdaf Habiboullah <mohamed-laghdaf-2.habiboullah@polymtl.ca>",
           "Geoffroy Leconte <geoffroy.leconte@polymtl.ca>",
           "Dominique Orban <dominique.orban@gmail.com>"]
 version = "0.1.0"


### PR DESCRIPTION
@dpo,

we can register the julia package from this commit.

We should remove the v0.0.1 and v0.0.2 releases on GitHub I think, can you take a look ? I suggest we make a v0.2.0 release instead.
