### PR TITLE
fix computation of ν in TRDH and LMTR

### DIFF
--- a/src/TRDH_alg.jl
+++ b/src/TRDH_alg.jl
@@ -345,13 +345,6 @@ function SolverCore.solve!(
   set_solver_specific!(stats, :nonsmooth_obj, hk)
 
   # models
-  φ1 = let ∇fk = ∇fk
-    d -> dot(∇fk, d)
-  end
-  mk1 = let ψ = ψ
-    d -> φ1(d) + ψ(d)::T
-  end
-
   φ = let ∇fk = ∇fk, dk = dk
     d -> begin
       result = zero(T)
@@ -368,7 +361,7 @@ function SolverCore.solve!(
 
   if reduce_TR
     prox!(s, ψ, mν∇fk, ν)
-    mks = mk1(s)
+    mks = mk(s)
 
     ξ1 = hk - mks + max(1, abs(hk)) * 10 * eps()
     sqrt_ξ_νInv = ξ1 ≥ 0 ? sqrt(ξ1 / ν) : sqrt(-ξ1 / ν)
@@ -489,7 +482,7 @@ function SolverCore.solve!(
 
     if reduce_TR
       prox!(s, ψ, mν∇fk, ν)
-      ξ1 = hk - mk1(s) + max(1, abs(hk)) * 10 * eps()
+      ξ1 = hk - mk(s) + max(1, abs(hk)) * 10 * eps()
       sqrt_ξ_νInv = ξ1 ≥ 0 ? sqrt(ξ1 / ν) : sqrt(-ξ1 / ν)
       solved = (ξ1 < 0 && sqrt_ξ_νInv ≤ neg_tol) || (ξ1 ≥ 0 && sqrt_ξ_νInv < atol)
       (ξ1 < 0 && sqrt_ξ_νInv > neg_tol) &&
@@ -497,11 +490,10 @@ function SolverCore.solve!(
     end
 
     iprox!(s, ψ, ∇fk, dk)
-
+    ξ = hk - mk(s) + max(1, abs(hk)) * 10 * eps()
     sNorm = χ(s)
 
-    if !reduce_TR
-      ξ = hk - mk(s) + max(1, abs(hk)) * 10 * eps()
+    if !reduce_TR      
       sqrt_ξ_νInv = ξ ≥ 0 ? sqrt(ξ / ν) : sqrt(-ξ / ν)
       solved = (ξ < 0 && sqrt_ξ_νInv ≤ neg_tol) || (ξ ≥ 0 && sqrt_ξ_νInv < atol)
       (ξ < 0 && sqrt_ξ_νInv > neg_tol) &&

--- a/test/test_bounds.jl
+++ b/test/test_bounds.jl
@@ -25,7 +25,6 @@ end
 for (mod, mod_name) ∈ ((SpectralGradientModel, "spg"),)
   # ((DiagonalPSBModel, "psb"),(DiagonalAndreiModel, "andrei"))   work but do not always terminate
   for (h, h_name) ∈ ((NormL0(λ), "l0"), (NormL1(λ), "l1"))
-    continue  # FIXME
     @testset "bpdn-with-bounds-$(mod_name)-TRDH-$(h_name)" begin
       x0 = zeros(bpdn2.meta.nvar)
       p = randperm(bpdn2.meta.nvar)[1:nz]


### PR DESCRIPTION
It looks like it was a bug.

See the last point of #231.