### PR TITLE
update SolverCore compat and add step_status

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -35,7 +35,7 @@ Percival = "0.7.2"
 ProximalOperators = "0.15"
 RegularizedProblems = "0.1.3"
 ShiftedProximalOperators = "0.2"
-SolverCore = "0.3.0"
+SolverCore = "0.3.10"
 julia = "^1.6.0"
 
 [extras]

--- a/src/LMTR_alg.jl
+++ b/src/LMTR_alg.jl
@@ -418,6 +418,7 @@ function SolverCore.solve!(
 
       σmax, found_σ = opnorm(solver.subpb.model.J)
       found_σ || error("operator norm computation failed")
+      set_step_status!(stats, :accepted)
     end
 
     if η2 ≤ ρk < Inf
@@ -438,6 +439,7 @@ function SolverCore.solve!(
         set_radius!(solver.subsolver.ψ, Δk)
         set_radius!(ψ, Δk)
       end
+      set_step_status!(stats, :rejected)
     end
 
     set_objective!(stats, fk + hk)

--- a/src/LM_alg.jl
+++ b/src/LM_alg.jl
@@ -416,6 +416,7 @@ function SolverCore.solve!(
         σmax, found_σ = opnorm(solver.subpb.model.J)
         found_σ || error("operator norm computation failed")
       end
+      set_step_status!(stats, :accepted)
     end
 
     if η2 ≤ ρk < Inf
@@ -424,6 +425,7 @@ function SolverCore.solve!(
 
     if ρk < η1 || ρk == Inf
       σk = σk * γ
+      set_step_status!(stats, :rejected)
     end
 
     m_monotone > 1 && (m_fh_hist[stats.iter % (m_monotone - 1) + 1] = fk + hk)

--- a/src/R2DH.jl
+++ b/src/R2DH.jl
@@ -402,6 +402,7 @@ function SolverCore.solve!(
       @. ∇fk⁻ = ∇fk - ∇fk⁻
       push!(D, s, ∇fk⁻) # update QN operator
       ∇fk⁻ .= ∇fk
+      set_step_status!(stats, :accepted)
     end
 
     if η2 ≤ ρk < Inf
@@ -410,6 +411,7 @@ function SolverCore.solve!(
 
     if ρk < η1 || ρk == Inf
       σk = σk * γ
+      set_step_status!(stats, :rejected)
     end
 
     set_objective!(stats, fk + hk)

--- a/src/R2N.jl
+++ b/src/R2N.jl
@@ -455,6 +455,7 @@ function SolverCore.solve!(
         λmax = power_method!(solver.subpb.model.B, solver.v0, solver.subpb.model.v, opnorm_maxiter)
       end
       found_λ || error("operator norm computation failed")
+      set_step_status!(stats, :accepted)
     end
 
     if η2 ≤ ρk < Inf
@@ -463,6 +464,7 @@ function SolverCore.solve!(
 
     if ρk < η1 || ρk == Inf
       σk = σk * γ
+      set_step_status!(stats, :rejected)
     end
 
     ν₁ = θ / (λmax + σk)

--- a/src/R2_alg.jl
+++ b/src/R2_alg.jl
@@ -473,6 +473,7 @@ function SolverCore.solve!(
       hk = hkn
       grad!(nlp, xk, ∇fk)
       shift!(ψ, xk)
+      set_step_status!(stats, :accepted)
     end
 
     if η2 ≤ ρk < Inf
@@ -480,6 +481,7 @@ function SolverCore.solve!(
     end
     if ρk < η1 || ρk == Inf
       σk = σk * γ
+      set_step_status!(stats, :rejected)
     end
 
     ν = 1 / σk

--- a/src/TRDH_alg.jl
+++ b/src/TRDH_alg.jl
@@ -453,6 +453,7 @@ function SolverCore.solve!(
       dk .= D.d
       DNorm = norm(D.d, Inf)
       ∇fk⁻ .= ∇fk
+      set_step_status!(stats, :accepted)
     end
 
     if η2 ≤ ρk < Inf
@@ -468,6 +469,7 @@ function SolverCore.solve!(
       else
         set_radius!(ψ, Δk)
       end
+      set_step_status!(stats, :rejected)
     end
 
     set_objective!(stats, fk + hk)

--- a/src/TR_alg.jl
+++ b/src/TR_alg.jl
@@ -467,6 +467,7 @@ function SolverCore.solve!(
       found_λ || error("operator norm computation failed")
 
       ∇fk⁻ .= ∇fk
+      set_step_status!(stats, :accepted)
     end
 
     if ρk < η1 || ρk == Inf
@@ -479,6 +480,7 @@ function SolverCore.solve!(
         set_radius!(ψ, Δk)
         set_radius!(solver.subsolver.ψ, Δk)
       end
+      set_step_status!(stats, :rejected)
     end
 
     m_monotone > 1 && (m_fh_hist[stats.iter % (m_monotone - 1) + 1] = fk + hk)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -37,6 +37,7 @@ for (mod, mod_name) ∈ ((x -> x, "exact"), (LSR1Model, "lsr1"), (LBFGSModel, "l
         @test length(out.solution) == bpdn.meta.nvar
         @test typeof(out.dual_feas) == eltype(out.solution)
         @test out.status == :first_order
+        @test out.step_status == (out.iter > 0 ? :accepted : :unknown)
       end
     end
   end
@@ -55,6 +56,7 @@ for (mod, mod_name) ∈ ((SpectralGradientModel, "spg"),)
       @test length(out.solution) == bpdn.meta.nvar
       @test typeof(out.dual_feas) == eltype(out.solution)
       @test out.status == :first_order
+      @test out.step_status == (out.iter > 0 ? :accepted : :unknown)
     end
   end
 end
@@ -71,6 +73,7 @@ for (mod, mod_name) ∈ ((LSR1Model, "lsr1"), (LBFGSModel, "lbfgs"))
       @test length(TR_out.solution) == bpdn.meta.nvar
       @test typeof(TR_out.dual_feas) == eltype(TR_out.solution)
       @test TR_out.status == :first_order
+      @test TR_out.step_status == (TR_out.iter > 0 ? :accepted : :unknown)
     end
   end
 end
@@ -90,6 +93,7 @@ for (h, h_name) ∈ ((NormL0(λ), "l0"), (NormL1(λ), "l1"), (IndBallL0(10 * com
       @test length(out.solution) == bpdn.meta.nvar
       @test typeof(out.dual_feas) == eltype(out.solution)
       @test out.status == :first_order
+      @test out.step_status == (out.iter > 0 ? :accepted : :unknown)
     end
   end
 end
@@ -105,6 +109,7 @@ for (h, h_name) ∈ ((NormL1(λ), "l1"),)
     @test length(LMTR_out.solution) == bpdn.meta.nvar
     @test typeof(LMTR_out.dual_feas) == eltype(LMTR_out.solution)
     @test LMTR_out.status == :first_order
+    @test LMTR_out.step_status == (LMTR_out.iter > 0 ? :accepted : :unknown)
   end
 end
 
@@ -129,6 +134,7 @@ for (mod, mod_name) ∈ (
         @test length(out.solution) == bpdn.meta.nvar
         @test typeof(out.dual_feas) == eltype(out.solution)
         @test out.status == :first_order
+        @test out.step_status == (out.iter > 0 ? :accepted : :unknown)
       end
     end
   end


### PR DESCRIPTION
Following https://github.com/JuliaSmoothOptimizers/SolverCore.jl/pull/130,
users can now access the step status in the callback through the `stats`.