### PR TITLE
adds an initialization value for the ratio in the solve function

### DIFF
--- a/src/R2_alg.jl
+++ b/src/R2_alg.jl
@@ -385,7 +385,7 @@ function SolverCore.solve!(
   end
 
   local ξ::T
-  local ρk::T
+  local ρk::T = zero(T)
   σk = max(1 / ν, σmin)
   ν = 1 / σk
   sqrt_ξ_νInv = one(T)


### PR DESCRIPTION
I suggest setting the initial value of the ratio to 0. In fact if verbose > 0 but there are 0 iterations, it results in the following error: exception = UndefVarError: `ρk` not defined in local scope