### PR TITLE
Add keywords argument for the subsolver of AL algorithm #327

### DIFF
--- a/src/AL_alg.jl
+++ b/src/AL_alg.jl
@@ -213,9 +213,6 @@ function SolverCore.solve!(
   max_iter::Int = 10000,
   max_time::Float64 = 30.0,
   max_eval::Int = -1,
-  subsolver_verbose::Int = 0,
-  subsolver_max_iter::Int = 100000,
-  subsolver_max_eval::Int = -1,
   init_penalty::T = T(10),
   factor_penalty_up::T = T(2),
   ctol::T = atol,
@@ -223,6 +220,7 @@ function SolverCore.solve!(
   factor_primal_linear_improvement::T = T(3 // 4),
   factor_decrease_subtol::T = T(1 // 4),
   dual_safeguard = project_y!,
+  sub_kwargs::NamedTuple = NamedTuple(),
 ) where {T, V}
   reset!(stats)
 
@@ -302,14 +300,12 @@ function SolverCore.solve!(
     solve!(
       solver.sub_solver,
       solver.sub_problem,
-      subout,
+      subout;
       x = solver.x,
       atol = subtol,
       rtol = zero(T),
       max_time = max_time - stats.elapsed_time,
-      max_eval = subsolver_max_eval < 0 ? rem_eval : min(subsolver_max_eval, rem_eval),
-      max_iter = subsolver_max_iter,
-      verbose = subsolver_verbose,
+      sub_kwargs...,
     )
     solver.x .= subout.solution
     solver.cx .= solver.sub_problem.model.cx

--- a/src/AL_alg.jl
+++ b/src/AL_alg.jl
@@ -116,6 +116,7 @@ If adopted, the Hessian is accessed as an abstract operator and need not be the 
 - `init_subtol::T = T(0.1)`: initial subproblem tolerance;
 - `factor_decrease_subtol::T = T(1/4)`: multiplicative factor to decrease the subproblem tolerance;
 - `dual_safeguard = (nlp::AugLagModel) -> nothing`: in-place function to modify, as needed, the dual estimate.
+- `sub_kwargs::NamedTuple = NamedTuple()`: a named tuple containing the keyword arguments to be sent to the subsolver. The solver will fail if invalid keyword arguments are provided to the subsolver. For example, if the subsolver is R2Solver, you can pass sub_kwargs = (max_iter = 100, σmin = 1e-6,)
 
 # Output
 

--- a/test/test_AL.jl
+++ b/test/test_AL.jl
@@ -5,7 +5,7 @@ problem_list = [:hs8]
   for problem in problem_list
     nlp = eval(problem)(backend = :optimized)
     for h in (NormL1(1.0),)
-      stats = AL(nlp, h, subsolver = R2Solver, atol = 1e-3, verbose = 1, subsolver_max_iter = 1000)
+      stats = AL(nlp, h, subsolver = R2Solver, atol = 1e-3, verbose = 1, sub_kwargs = (max_iter = 1000,))
       @test stats.status == :first_order
       @test stats.primal_feas <= 1e-2
       @test stats.dual_feas <= 1e-2
@@ -18,7 +18,7 @@ problem_list = [:hs8]
         subsolver = R2NSolver,
         atol = 1e-3,
         verbose = 1,
-        subsolver_max_iter = 1000,
+        sub_kwargs = (max_iter = 1000,),
       )
       @test stats.status == :first_order
       @test stats.primal_feas <= 1e-2


### PR DESCRIPTION
Add a feature `sub_kwargs` to pass a keywords argument for the subsolver of the Augmented Lagrangian algorithm. 
This allows for instance to pass a callback in argument of the subsolver.